### PR TITLE
Replacing old endpoint URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 provstore-api [![PyPI version](https://badge.fury.io/py/provstore-api.svg)](http://badge.fury.io/py/provstore-api) [![Build Status](https://travis-ci.org/millar/provstore-api.svg?branch=master)](https://travis-ci.org/millar/provstore-api) [![Coverage Status](https://coveralls.io/repos/millar/provstore-api/badge.png)](https://coveralls.io/r/millar/provstore-api)
 =========
 
-Client for the [ProvStore](https://provenance.ecs.soton.ac.uk/store/)'s [API](https://provenance.ecs.soton.ac.uk/store/help/api/).
+Client for the [ProvStore](https://openprovenance.org/store/)'s [API](https://openprovenance.org/store/help/api/).
 
 ## Installation
 ```bash
@@ -16,7 +16,7 @@ To use the client import the API and configure your access credentials:
 ```python
 from provstore.api import Api
 
-# API key can be found at https://provenance.ecs.soton.ac.uk/store/account/developer/
+# API key can be found at https://openprovenance.org/store/account/developer/
 api = Api(userame="your_provstore_username", api_key="your_api_key")
 ```
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@
 provstore-api
 ==========================================
 
-provstore-api is a python API client for `ProvStore <https://provenance.ecs.soton.ac.uk/store/>`_.
+provstore-api is a python API client for `ProvStore <https://openprovenance.org/store/>`_.
 
 Installation
 ------------

--- a/provstore/api.py
+++ b/provstore/api.py
@@ -68,7 +68,7 @@ class Api(object):
                  base_url=None):
 
         if base_url is None:
-            self.base_url = 'https://provenance.ecs.soton.ac.uk/store/api/v0'
+            self.base_url = 'https://openprovenance.org/store/api/v0'
         else:
             self.base_url = base_url.rstrip('/')
 

--- a/provstore/document.py
+++ b/provstore/document.py
@@ -119,7 +119,7 @@ class Document(object):
         Example::
           >>> api = Api()
           >>> api.document.get(148)
-          https://provenance.ecs.soton.ac.uk/store/api/v0/documents/148
+          https://openprovenance.org/store/api/v0/documents/148
           >>> api.id
           148
           >>> api.name
@@ -339,7 +339,7 @@ class Document(object):
 
         :Example:
           >>> stored_document.url
-          'https://provenance.ecs.soton.ac.uk/store/documents/148'
+          'https://openprovenance.org/store/documents/148'
         """
         if not self.abstract:
             return "%s/documents/%i" % ("/".join(self._api.base_url.split("/")[:-2]), self.id)


### PR DESCRIPTION
If merged, this PR will:
- Replace the old API endpoint URL (https://provenance.ecs.soton.ac.uk/store/api/v0) for the current URL (https://openprovenance.org/store/api/v0).

This is a quick fix for #8. Shout out to @jvfe for noticing it in vinisalazar/bioprov#23.

I fixed this independently in my own project, but an update to the PyPI distribution of provstore-api would be helpful to other users.

Thanks,

V